### PR TITLE
Feature/pc sd viewer v4

### DIFF
--- a/cocos/2d/CCRenderTexture.h
+++ b/cocos/2d/CCRenderTexture.h
@@ -346,7 +346,7 @@ protected:
     void onEnd();
     void clearColorAttachment();
 
-    void onSaveToFile(const std::string& fileName, bool isRGBA = true, bool forceNonPMA = false);
+    virtual void onSaveToFile(const std::string& fileName, bool isRGBA = true, bool forceNonPMA = false); // DESKTOP
 
     bool         _keepMatrix = false;
     Rect         _rtTextureRect;

--- a/cocos/base/CCConsole.h
+++ b/cocos/base/CCConsole.h
@@ -60,7 +60,11 @@ static const int MAX_LOG_LENGTH = 16*1024;
 /**
  @brief Output Debug message.
  */
-void CC_DLL log(const char * format, ...) CC_FORMAT_PRINTF(1, 2);
+#ifndef PLATFORM_DESKTOP
+void CC_DLL log(const char * format, ...); CC_FORMAT_PRINTF(1, 2);
+#else
+void CC_DLL log(const char * format, ...);// DESKTOP
+#endif
 
 /** Console is helper class that lets the developer control the game from TCP connection.
  Console will spawn a new thread that will listen to a specified TCP port.

--- a/cocos/base/CCDirector.cpp
+++ b/cocos/base/CCDirector.cpp
@@ -80,7 +80,8 @@ NS_CC_BEGIN
 // FIXME: it should be a Director ivar. Move it there once support for multiple directors is added
 
 // singleton stuff
-static Director *s_SharedDirector = nullptr;
+//static Director *s_SharedDirector = nullptr;  // DESKTOP
+Director* Director::s_SharedDirector = nullptr; // DESKTOP
 
 #define kDefaultFPS        60  // 60 frames per second
 extern const char* cocos2dVersion();

--- a/cocos/base/CCDirector.h
+++ b/cocos/base/CCDirector.h
@@ -646,6 +646,8 @@ protected:
 
     // GLView will recreate stats labels to fit visible rect
     friend class GLView;
+    
+    static Director* s_SharedDirector;    // DESKTOP
 };
 
 // end of base group

--- a/cocos/base/ccUTF8.h
+++ b/cocos/base/ccUTF8.h
@@ -63,7 +63,11 @@ std::string toString(T arg)
     return ss.str();
 }
 
-std::string CC_DLL format(const char* format, ...) CC_FORMAT_PRINTF(1, 2);
+#ifndef PLATFORM_DESKTOP
+std::string CC_DLL format(const char* format, ...); CC_FORMAT_PRINTF(1, 2);
+#else
+std::string CC_DLL format(const char* format, ...); // DESKTOP
+#endif
 
 /**
  *  @brief Converts from UTF8 string to UTF16 string.

--- a/cocos/platform/win32/CCFileUtils-win32.cpp
+++ b/cocos/platform/win32/CCFileUtils-win32.cpp
@@ -373,6 +373,12 @@ string FileUtilsWin32::getWritablePath() const
     return convertPathFormatToUnixStyle(StringWideCharToUtf8(retPath));
 }
 
+// DESKTOP
+virtual std::string getDownloadResourcePath(const std::string& dirname) const
+{
+    return FileUtils::getInstance()->getDefaultResourceRootPath();
+}
+
 bool FileUtilsWin32::renameFile(const std::string &oldfullpath, const std::string& newfullpath) const
 {
     CCASSERT(!oldfullpath.empty(), "Invalid path");

--- a/cocos/platform/win32/CCFileUtils-win32.h
+++ b/cocos/platform/win32/CCFileUtils-win32.h
@@ -48,6 +48,7 @@ public:
     /* override functions */
     bool init();
     virtual std::string getWritablePath() const override;
+    virtual std::string getDownloadResourcePath(const std::string& dirname) const override; // DESKTOP
     virtual bool isAbsolutePath(const std::string& strPath) const override;
     virtual std::string getSuitableFOpen(const std::string& filenameUtf8) const override;
     virtual long getFileSize(const std::string &filepath);


### PR DESCRIPTION
Windows版SDViewerの実装に伴う改修をしました。
・ビルドエラー対応
・連番テクスチャの保存先を変更するための対応を追加
・固定フレームレート対応
・ダウンロードリソースのパス取得を追加
※3系のCocos2d-xで対応していたものを持ってきたので、別途対応が必要が可能性があります。