### PR TITLE
Sprite : setTextureでShaderが外れる不具合を修正

### DIFF
--- a/cocos/2d/CCSprite.cpp
+++ b/cocos/2d/CCSprite.cpp
@@ -417,8 +417,11 @@ void Sprite::setProgramState(backend::ProgramState *programState)
 
 void Sprite::setTexture(Texture2D *texture)
 {
-    auto isETC1 = texture && texture->getAlphaTextureName();
-    setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
+    if (_programState == nullptr || _programState->getProgram()->getProgramType() == backend::ProgramType::POSITION_TEXTURE_COLOR)
+    {
+        auto isETC1 = texture && texture->getAlphaTextureName();
+        setProgramState((isETC1) ? backend::ProgramType::ETC1 : backend::ProgramType::POSITION_TEXTURE_COLOR);
+    }
     CCASSERT(! _batchNode || (texture &&  texture == _batchNode->getTexture()), "CCSprite: Batched sprites should use the same texture as the batchnode");
     // accept texture==nil as argument
     CCASSERT( !texture || dynamic_cast<Texture2D*>(texture), "setTexture expects a Texture2D. Invalid argument");


### PR DESCRIPTION
setTextureでShaderが外れる不具合を修正しました。
参考）
https://zenn.dev/asteroid/articles/4c96ccfa09f12c418909